### PR TITLE
rename pr to pullrequest variable

### DIFF
--- a/scripts/update-wiki-from-pr.ps1
+++ b/scripts/update-wiki-from-pr.ps1
@@ -21,12 +21,12 @@ function Get-PullRequestInfo {
     $prUrl = "https://api.github.com/repos/$Owner/$Repo/pulls/$PR"
     $filesUrl = "https://api.github.com/repos/$Owner/$Repo/pulls/$PR/files"
 
-    $pr = Invoke-RestMethod -Uri $prUrl -Headers $headers
+    $pullrequest = Invoke-RestMethod -Uri $prUrl -Headers $headers
     $files = Invoke-RestMethod -Uri $filesUrl -Headers $headers
 
     return @{
-        Title = $pr.title
-        Body = $pr.body
+        Title = $pullrequest.title
+        Body = $pullrequest.body
         Files = $files | ForEach-Object { $_.filename }
     }
 }


### PR DESCRIPTION
Resolves an issue where the $PR variable being passed as a parameter was being used again for the $pr variable in the function when getting the pull request response body.