### PR TITLE
Fix wiki push when page unchanged

### DIFF
--- a/scripts/update-wiki-from-pr.ps1
+++ b/scripts/update-wiki-from-pr.ps1
@@ -97,8 +97,15 @@ function Push-ToWiki {
     git config user.email "autowikibot@localhost"
     git config user.name "AutoWikiBot"
     git add $PageName
-    git commit -m "Auto-update: $PageName"
-    git push origin $branch
+
+    git diff --cached --quiet
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "No wiki changes detected for $PageName"
+    }
+    else {
+        git commit -m "Auto-update: $PageName"
+        git push origin $branch
+    }
     Pop-Location
 
     Remove-Item -Path $tempDir -Recurse -Force


### PR DESCRIPTION
## Summary
- avoid failing when the generated wiki page has no changes

## Testing
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68810572244c832e9a570e2b8200d365